### PR TITLE
Fix iconv  throwing exception

### DIFF
--- a/images/php-fpm/Dockerfile
+++ b/images/php-fpm/Dockerfile
@@ -4,6 +4,10 @@ ARG DOCKER_IMAGE_FOLDER
 ARG GROUP_ID
 ARG USER_ID
 
+# iconv fix (https://github.com/docker-library/php/issues/240#issuecomment-763112749)
+RUN apk add --upgrade gnu-libiconv
+ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so
+
 # php gd dependencies
 RUN apk add zlib-dev
 RUN apk add jpeg-dev


### PR DESCRIPTION
# Provided exceptoion
`Exception #0 (Exception): Notice: iconv(): Wrong charset, conversion from UTF-8 to ASCII//TRANSLIT//IGNORE is not allowed in ...`

# Code snippet for testing
`$string = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $string);`

# Solution
Topic: https://github.com/docker-library/php/issues/240#issuecomment-763112749

