### PR TITLE
Remove flag "--ignore-platform-reqs"

### DIFF
--- a/bin/new-project/magento
+++ b/bin/new-project/magento
@@ -29,7 +29,7 @@ ${DOCKER_BIN_DIRECTORY}/compose/up
 cd ${DOCKER_DIRECTORY}
 
 # Create new project
-docker-compose exec php-fpm sh -c 'composer create-project --ignore-platform-reqs --repository-url=https://repo.magento.com/ magento/project-community-edition=$1 /home/dockeruser/temp && rm -rf /home/dockeruser/temp/var/log && rm -rf /home/dockeruser/temp/var/report && cp -r /home/dockeruser/temp/. /home/dockeruser/magento && rm -rf /home/dockeruser/temp'
+docker-compose exec php-fpm sh -c 'composer create-project --repository-url=https://repo.magento.com/ magento/project-community-edition=$1 /home/dockeruser/temp && rm -rf /home/dockeruser/temp/var/log && rm -rf /home/dockeruser/temp/var/report && cp -r /home/dockeruser/temp/. /home/dockeruser/magento && rm -rf /home/dockeruser/temp'
 
 echo "New Magento project has been created."
 


### PR DESCRIPTION
This causes errors with some packages, for example
**laminas-mail V 0.17.0** require version `"php": "~8.0.0 || ~8.1.0" `(Version contains functionalities deprecated in PHP version < 8)
docker image is running on 7.16.0 (expect to install **laminas-mail V 0.16.0** not **laminas-mail V 0.17.0**)

Result: 
these changes throw error: https://github.com/laminas/laminas-mail/pull/203/files#diff-d04014cbdc94e3004924376170e7f30adcbef900ff528dc166fe175c6452f969L397
`Fatal error: Cannot use ::class with dynamic class name`

Expected: to install package  **laminas-mail V 0.16.0** not the latest